### PR TITLE
Update angular-avatar.js to allow custom color palette

### DIFF
--- a/src/angular-avatar.js
+++ b/src/angular-avatar.js
@@ -32,7 +32,7 @@
                 string:'@string',
                 cornerRadius: '@cornerRadius',
                 pictureFormat: '@pictureFormat',
-                colorsPalette: '@colorsPalette',
+                colorsPalette: '=colorsPalette',
                 autoColor: '@autoColor',
                 fontWeight: '@fontWeight',
                 fontScale: '@fontScale',


### PR DESCRIPTION
To allow customizing the color palette, we need to pass an array. Therefore, I changed the binding of the array in the directive. This allows:
colors-palette='["#607D8B" ,"#ECEFF1","#CFD8DC","#B0BEC5","#90A4AE","#78909C", "#607D8B","#546E7A","#455A64","#37474F","#263238"]'

or
colors-palette='vm.colorsPalette'

where vm.colorsPalette is defined in the controller:
    var vm = this;
    vm.colorsPalette = ["#607D8B" ,"#ECEFF1","#CFD8DC","#B0BEC5","#90A4AE","#78909C", "#607D8B","#546E7A","#455A64","#37474F","#263238"];
