### PR TITLE
declare angular-mocks as dev dependency in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,9 @@
   ],
   "dependencies": {
     "angular": "1.4.5",
-    "angular-mocks": "1.4.5"
+  },
+  "devDependencies": {
+     "angular-mocks": "1.4.5"
   },
   "license": "MIT",
   "ignore": [


### PR DESCRIPTION
angular-mocks was wrongly declared as a general dependency in bower.js.