### PR TITLE
feat: Add ability to use auto-color based on the entire string

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Run the live example in plunker: http://plnkr.co/edit/TfCxUn?p=preview
 | `style`              | null  | Use this attribute in the same way it is used in common html tags. |
 | `picture-format`     | png   | Set `picture-format="jpeg"` and the avatar will be rendered as a jpeg. If not set, png format will be used by default. |
 | `auto-color`         | false | By default the generated picture will have a black background if no color is assigned. Setting `auto-color="true"` will automatically assign a color to the avatar's background depending on the combination of characters used. |
+| `use-full-string-for-colors` | false | When using `auto-color` and `string`, determine the color based on all of the characters in the string, not just the initials |
 | `colors-palette`     | default colors | Change the palette used by `auto-color`. You can provide an array in your HTML or via the controller. |
 | `text-shadow`        | false | This paints an elegant thin shadow around the edges of each letter. |
 

--- a/dist/angular-avatar.js
+++ b/dist/angular-avatar.js
@@ -35,6 +35,7 @@
                 pictureFormat: '@pictureFormat',
                 colorsPalette: '=colorsPalette',
                 autoColor: '=autoColor',
+                useFullStringForColors: '=useFullStringForColors',
                 fontWeight: '@fontWeight',
                 fontScale: '@fontScale',
                 textShadow: '=textShadow',
@@ -61,6 +62,7 @@
                     _picture_format = "png",
                     _colors_palette = ["#bdc3c7","#6f7b87","#2c3e50","#2f3193","#662d91","#922790","#ec2176","#ed1c24","#f36622","#f8941e","#fab70f","#fdde00","#d1d219","#8ec73f","#00a650","#00aa9c","#00adef","#0081cd","#005bab"],
                     _autoColor = false,
+                    _useFullStringForColors = false,
                     _font_weight = 100,
                     _font_scale = 100,
                     _text_shadow = false,
@@ -147,13 +149,24 @@
                     } else {
 
                         if (scope.autoColor != undefined) {
+                            if (scope.useFullStringForColors != undefined) {
+                                _useFullStringForColors = scope.useFullStringForColors;
+                            }
 
                             _autoColor = scope.autoColor;
                             if ( _autoColor === true ) {
-                                var i, lon = _str.length, charIndex=0,colorIndex;
-                                for(i=0; i<lon;i++) charIndex = _str.charCodeAt(i);
-                                colorIndex = charIndex % _colors_palette.length;
-                                _bgcolor = _colors_palette[ colorIndex ];
+                                if (_useFullStringForColors === true && scope.string != undefined) {
+                                    var i, lon = scope.string.length, charIndex=0,colorIndex;
+                                    for(i=0; i<lon;i++) charIndex += scope.string.charCodeAt(i);
+                                    colorIndex = charIndex % _colors_palette.length;
+                                    _bgcolor = _colors_palette[ colorIndex ];
+                                    console.log(scope.string, charIndex, colorIndex);
+                                } else {
+                                    var i, lon = _str.length, charIndex=0,colorIndex;
+                                    for(i=0; i<lon;i++) charIndex += _str.charCodeAt(i);
+                                    colorIndex = charIndex % _colors_palette.length;
+                                    _bgcolor = _colors_palette[ colorIndex ];
+                                }
                             }
                         }                     
                     }

--- a/src/angular-avatar.js
+++ b/src/angular-avatar.js
@@ -35,6 +35,7 @@
                 pictureFormat: '@pictureFormat',
                 colorsPalette: '=colorsPalette',
                 autoColor: '=autoColor',
+                useFullStringForColors: '=useFullStringForColors',
                 fontWeight: '@fontWeight',
                 fontScale: '@fontScale',
                 textShadow: '=textShadow',
@@ -61,6 +62,7 @@
                     _picture_format = "png",
                     _colors_palette = ["#bdc3c7","#6f7b87","#2c3e50","#2f3193","#662d91","#922790","#ec2176","#ed1c24","#f36622","#f8941e","#fab70f","#fdde00","#d1d219","#8ec73f","#00a650","#00aa9c","#00adef","#0081cd","#005bab"],
                     _autoColor = false,
+                    _useFullStringForColors = false,
                     _font_weight = 100,
                     _font_scale = 100,
                     _text_shadow = false,
@@ -147,13 +149,24 @@
                     } else {
 
                         if (scope.autoColor != undefined) {
+                            if (scope.useFullStringForColors != undefined) {
+                                _useFullStringForColors = scope.useFullStringForColors;
+                            }
 
                             _autoColor = scope.autoColor;
                             if ( _autoColor === true ) {
-                                var i, lon = _str.length, charIndex=0,colorIndex;
-                                for(i=0; i<lon;i++) charIndex = _str.charCodeAt(i);
-                                colorIndex = charIndex % _colors_palette.length;
-                                _bgcolor = _colors_palette[ colorIndex ];
+                                if (_useFullStringForColors === true && scope.string != undefined) {
+                                    var i, lon = scope.string.length, charIndex=0,colorIndex;
+                                    for(i=0; i<lon;i++) charIndex += scope.string.charCodeAt(i);
+                                    colorIndex = charIndex % _colors_palette.length;
+                                    _bgcolor = _colors_palette[ colorIndex ];
+                                    console.log(scope.string, charIndex, colorIndex);
+                                } else {
+                                    var i, lon = _str.length, charIndex=0,colorIndex;
+                                    for(i=0; i<lon;i++) charIndex += _str.charCodeAt(i);
+                                    colorIndex = charIndex % _colors_palette.length;
+                                    _bgcolor = _colors_palette[ colorIndex ];
+                                }
                             }
                         }                     
                     }


### PR DESCRIPTION
Previously, auto-color only checked the initials. With this option enabled, it looks at all of the characters in the string, allowing two avatars with the same initials, derived from different strings, to have different colors

Also updates auto-color on just the initials to look at more than just the last character